### PR TITLE
Update RequestAPICommand.php

### DIFF
--- a/Command/RequestAPICommand.php
+++ b/Command/RequestAPICommand.php
@@ -16,8 +16,8 @@ class RequestAPICommand extends ContainerAwareCommand
         $this
             ->setName('ac:request-api')
             ->addArgument('rest-url', InputArgument::REQUIRED, "REST api endpoint, like /rest/api/2/issue/{issueIdOrKey}")
-            ->addOption('client-key', "c", InputOption::VALUE_OPTIONAL | InputOption::VALUE_REQUIRED, "Client-key from tenant")
-            ->addOption('tenant-id', "t", InputOption::VALUE_OPTIONAL | InputOption::VALUE_REQUIRED, "Tenant-id")
+            ->addOption('client-key', "c", InputOption::VALUE_REQUIRED, "Client-key from tenant")
+            ->addOption('tenant-id', "t", InputOption::VALUE_REQUIRED, "Tenant-id")
             ->setDescription('Request REST end-points. 
 Documentation available on https://docs.atlassian.com/jira/REST/cloud/');
     }

--- a/Command/RequestAPICommand.php
+++ b/Command/RequestAPICommand.php
@@ -6,6 +6,7 @@ use AtlassianConnectBundle\Model\JWTRequest;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RequestAPICommand extends ContainerAwareCommand
@@ -14,24 +15,32 @@ class RequestAPICommand extends ContainerAwareCommand
     {
         $this
             ->setName('ac:request-api')
-            ->addArgument('client-key', InputArgument::REQUIRED)
-            ->addArgument('rest-url', InputArgument::REQUIRED)
-            ->setDescription('Request REST end-points');
+            ->addArgument('rest-url', InputArgument::REQUIRED, "REST api endpoint, like /rest/api/2/issue/{issueIdOrKey}")
+            ->addOption('client-key', "c", InputOption::VALUE_OPTIONAL | InputOption::VALUE_REQUIRED, "Client-key from tenant")
+            ->addOption('tenant-id', "t", InputOption::VALUE_OPTIONAL | InputOption::VALUE_REQUIRED, "Tenant-id")
+            ->setDescription('Request REST end-points. 
+Documentation available on https://docs.atlassian.com/jira/REST/cloud/');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $tenant = $input->getArgument('client-key');
         $restUrl = $input->getArgument('rest-url');
         $em = $this->getContainer()->get('doctrine')->getManager();
-        $tenant = $em->getRepository('AtlassianConnectBundle:Tenant')
-            ->findOneByClientKey($tenant);
+        if($input->getOption("tenant-id")) {
+            $tenant = $em->getRepository('AtlassianConnectBundle:Tenant')
+                ->find($input->getOption("tenant-id"));
+        } elseif($input->getOption("client-key")) {
+            $tenant = $em->getRepository('AtlassianConnectBundle:Tenant')
+                ->findOneByClientKey($input->getOption('client-key'));
+        } else {
+            throw new \Exception("Please provide client-key or tenant-id");
+        }
 
         $request = new JWTRequest($tenant);
         $json = $request->get($restUrl);
 
         $output->writeln('');
-        var_export($json);
+        print json_encode($json, JSON_PRETTY_PRINT);
         $output->writeln('');
     }
 }


### PR DESCRIPTION
added ability to provide either client-key OR tenant id

```
./app/console ac:request-api -t 1 /rest/api/2/issue/{issueIdOrKey}
./app/console ac:request-api --tenant-id=1 /rest/api/2/issue/{issueIdOrKey}
```