### PR TITLE
Fix delete error caused by Atlassian apis returning 204 No content

### DIFF
--- a/Model/JWTRequest.php
+++ b/Model/JWTRequest.php
@@ -80,9 +80,7 @@ class JWTRequest
         $url = $this->buildURL($restUrl);
         $options = ['headers' => $this->buildAuthHeader('DELETE', $restUrl)];
 
-        $response = $this->client->delete($url, $options);
-
-        return $response->json();
+        $this->client->delete($url, $options);
     }
 
     private function buildAuthHeader($method, $restUrl)


### PR DESCRIPTION
The Atlassian apis return 204 no content on delete requests, and because of that the $response->json() call causes a crash, this PR removes that call