### PR TITLE
Transform JWTAuthenticator from simple_preauth to guard authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,20 +68,21 @@ Sample configuration in `config.yml`:
 
 ### Step 4. Security configuration
 
-To configure security part - use the following configuration in your `security.yml`
+To configure security part - use the following configuration in your `security.yml`. If you have another firewall that has the `"^/"` pattern, be sure to set the `jwt_secured_area` firewall first.
 
 ```yaml
     security:
         providers:
             jwt_user_provider:
                 id: jwt_user_provider
-    
         firewalls:
             jwt_secured_area:
                 pattern: "^/protected"
                 stateless: true
-                simple_preauth:
-                    authenticator: jwt_authenticator
+                guard:
+                    authenticators:
+                        - jwt_authenticator
+                provider: jwt_user_provider
 ```
     
 ### Step 5. Include Routes

--- a/Security/JWTUserProvider.php
+++ b/Security/JWTUserProvider.php
@@ -63,7 +63,7 @@ class JWTUserProvider implements UserProviderInterface
     /**
      * @param mixed $clientKey
      *
-     * @return TenantInterface
+     * @return TenantInterface|UserInterface
      */
     public function loadUserByUsername($clientKey): TenantInterface
     {

--- a/Tests/Security/JWTAuthenticatorTest.php
+++ b/Tests/Security/JWTAuthenticatorTest.php
@@ -1,0 +1,208 @@
+<?php declare(strict_types = 1);
+
+namespace AtlassianConnectBundle\Tests\Security;
+
+use AtlassianConnectBundle\Entity\Tenant;
+use AtlassianConnectBundle\Security\JWTAuthenticator;
+use AtlassianConnectBundle\Security\JWTUserProvider;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * Class JWTAuthenticatorTest
+ */
+final class JWTAuthenticatorTest extends TestCase
+{
+    /**
+     * @var JWTUserProvider|MockObject
+     */
+    private $userProvider;
+
+    /**
+     * @var KernelInterface|MockObject
+     */
+    private $kernel;
+
+    /**
+     * @var ManagerRegistry|MockObject
+     */
+    private $managerRegistry;
+
+    /**
+     * @var EntityManagerInterface|MockObject
+     */
+    private $em;
+
+    /**
+     * @var string
+     */
+    private $tenantEntityClass;
+
+    /**
+     * @var int
+     */
+    private $devTenant;
+
+    /**
+     * @var JWTAuthenticator
+     */
+    private $jwtAuthenticator;
+
+    /**
+     * Setup method
+     */
+    public function setUp(): void
+    {
+        $this->userProvider = $this->createMock(JWTUserProvider::class);
+        $this->kernel = $this->createMock(KernelInterface::class);
+        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->tenantEntityClass = Tenant::class;
+        $this->devTenant = 1;
+
+        $this->managerRegistry
+            ->method('getManager')
+            ->willReturn($this->em);
+
+        $this->jwtAuthenticator = new JWTAuthenticator(
+            $this->userProvider,
+            $this->kernel,
+            $this->managerRegistry,
+            $this->tenantEntityClass,
+            $this->devTenant
+        );
+    }
+
+    /**
+     * Tests if the request is supported
+     */
+    public function testSupportsRequest(): void
+    {
+        $request = new Request(['jwt' => 'token']);
+        $this->assertTrue($this->jwtAuthenticator->supports($request));
+
+        $request = new Request();
+        $request->headers->set('authorization', 'jwt token');
+        $this->assertTrue($this->jwtAuthenticator->supports($request));
+
+        $request = new Request();
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getEnvironment')
+            ->willReturn('dev');
+
+        $this->assertTrue($this->jwtAuthenticator->supports($request));
+    }
+
+    /**
+     * Tests if the request is not supportd
+     */
+    public function testDoesNotSupportRequest(): void
+    {
+        $request = new Request();
+        $this->assertFalse($this->jwtAuthenticator->supports($request));
+    }
+
+    /**
+     * Test if the getCredentials method returns a valid array
+     */
+    public function testGetsCredentials(): void
+    {
+        $request = new Request(['jwt' => 'token']);
+        $credentials = $this->jwtAuthenticator->getCredentials($request);
+        $this->assertIsArray($credentials);
+        $this->assertArrayHasKey('jwt', $credentials);
+        $this->assertEquals('token', $credentials['jwt']);
+
+        $request = new Request();
+        $request->headers->set('authorization', 'jwt token');
+        $credentials = $this->jwtAuthenticator->getCredentials($request);
+        $this->assertIsArray($credentials);
+        $this->assertArrayHasKey('jwt', $credentials);
+        $this->assertEquals('token', $credentials['jwt']);
+    }
+
+    /**
+     * Test if the getCredentials method returns null when no jwt token is passed
+     */
+    public function testGetsCredentialsTokenDoesNotExist(): void
+    {
+        $this->kernel
+            ->expects($this->once())
+            ->method('getEnvironment')
+            ->willReturn('prod');
+
+        $request = new Request();
+        $credentials = $this->jwtAuthenticator->getCredentials($request);
+        $this->assertNull($credentials);
+    }
+
+    /**
+     * Test if the getCredentials method can get the credentials in dev mode
+     */
+    public function testGetsCredentialsOnDevTenant(): void
+    {
+        $tenant = new Tenant();
+        $tenant->setClientKey('client_key');
+        $tenant->setSharedSecret('shared_secret');
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository
+            ->expects($this->once())
+            ->method('find')
+            ->with(1)
+            ->willReturn($tenant);
+
+        $this->em
+            ->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($repository);
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getEnvironment')
+            ->willReturn('dev');
+
+        $request = new Request();
+        $credentials = $this->jwtAuthenticator->getCredentials($request);
+        $this->assertIsArray($credentials);
+        $this->assertArrayHasKey('jwt', $credentials);
+        $this->assertIsString($credentials['jwt']);
+    }
+
+    /**
+     * Test if a user gets fetched
+     */
+    public function testGetsUser(): void
+    {
+        $token = [
+            'iss' => 'iss',
+            'sub' => 'username',
+        ];
+
+        $tenant = new Tenant();
+
+        $this->userProvider
+            ->expects($this->once())
+            ->method('getDecodedToken')
+            ->willReturn((object) $token);
+
+        $this->userProvider
+            ->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with('iss')
+            ->willReturn($tenant);
+
+        $user = $this->jwtAuthenticator->getUser(['jwt' => 'token'], $this->createMock(UserProviderInterface::class));
+
+        $this->assertInstanceOf(Tenant::class, $user);
+        $this->assertEquals('username', $tenant->getUsername());
+    }
+}


### PR DESCRIPTION
Symfony 4.2 deprecated the simple_preauth method in the security component. 

This PR transforms the simple_preauth authenticator to a guard authenticator. Some unit tests were added to test the authenticator.