### PR TITLE
Fix user routing deprecation for symfony 4.1

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,14 +1,14 @@
 atlassian_connect_descriptor:
     path: /atlassian-connect.json
     defaults:
-        _controller: AtlassianConnectBundle:Descriptor:index
+        _controller: AtlassianConnectBundle\Controller\DescriptorController::indexaction
 
 atlassian_connect_handshake:
     path: /handshake
     defaults:
-        _controller: AtlassianConnectBundle:Handshake:register
+        _controller: AtlassianConnectBundle\Controller\HandshakeController::registerAction
 
 atlassian_connect_unlicensed:
     path: /protected/unlicensed
     defaults:
-        _controller: AtlassianConnectBundle:Unlicensed:unlicensed
+        _controller: AtlassianConnectBundle\Controller\UnlicensedController::unlicensedAction


### PR DESCRIPTION
This PR fixes the following deprecation notice starting from symfony 4.1:

```User Deprecated: Referencing controllers with AtlassianConnectBundle:Unlicensed:unlicensed is deprecated since Symfony 4.1, use "AtlassianConnectBundle\Controller\UnlicensedController::unlicensedAction" instead.```