### PR TITLE
Refactor the JWTUserProvider and clean up code

### DIFF
--- a/Tests/DependencyInjection/AtlassianConnectExtensionTest.php
+++ b/Tests/DependencyInjection/AtlassianConnectExtensionTest.php
@@ -6,8 +6,8 @@ use AtlassianConnectBundle\Controller\DescriptorController;
 use AtlassianConnectBundle\Controller\HandshakeController;
 use AtlassianConnectBundle\Controller\UnlicensedController;
 use AtlassianConnectBundle\DependencyInjection\AtlassianConnectExtension;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -48,7 +48,7 @@ class AtlassianConnectExtensionTest extends TestCase
         $this->container->set(RouterInterface::class, new \stdClass());
         $this->container->set(KernelInterface::class, new \stdClass());
         $this->container->set(TokenStorageInterface::class, new \stdClass());
-        $this->container->set(ManagerRegistry::class, new \stdClass());
+        $this->container->set(EntityManagerInterface::class, new \stdClass());
         $this->container->set(ObjectManager::class, new \stdClass());
         $this->container->set(LoggerInterface::class, new \stdClass());
         $this->container->set('twig', new \stdClass());

--- a/Tests/Security/JWTUserProviderTest.php
+++ b/Tests/Security/JWTUserProviderTest.php
@@ -1,0 +1,171 @@
+<?php declare(strict_types = 1);
+
+namespace AtlassianConnectBundle\Tests\Security;
+
+use AtlassianConnectBundle\Entity\Tenant;
+use AtlassianConnectBundle\Entity\TenantInterface;
+use AtlassianConnectBundle\Security\JWTUserProvider;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Class JWTUserProviderTest
+ */
+final class JWTUserProviderTest extends TestCase
+{
+    /**
+     * @var EntityManagerInterface|MockObject
+     */
+    private $entityManager;
+
+    /**
+     * @var JWTUserProvider
+     */
+    private $userProvider;
+
+    /**
+     * @var EntityRepository|MockObject
+     */
+    private $entityRepository;
+
+    /**
+     * Setup properties
+     */
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $this->entityRepository = $this->createMock(EntityRepository::class);
+        $this->entityManager
+            ->method('getRepository')
+            ->willReturn($this->entityRepository);
+
+        $this->userProvider = new JWTUserProvider(
+            $this->entityManager,
+            Tenant::class
+        );
+    }
+
+    /**
+     * @dataProvider jwtTokenProvider
+     *
+     * @param string $jwt
+     * @param string $secret
+     * @param string $isstoken
+     * @param string $sub
+     * @param string $name
+     * @param int    $iat
+     */
+    public function testItDecodesAToken(string $jwt, string $secret, string $isstoken, string $sub, string $name, int $iat): void
+    {
+        $tenant = $this->createMock(TenantInterface::class);
+        $tenant
+            ->expects($this->once())
+            ->method('getSharedSecret')
+            ->willReturn($secret);
+
+        $this->entityRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['clientKey' => $isstoken])
+            ->willReturn($tenant);
+
+        $token = $this->userProvider->getDecodedToken($jwt);
+
+        $this->assertEquals($sub, $token->sub);
+        $this->assertEquals($name, $token->name);
+        $this->assertEquals($isstoken, $token->iss);
+        $this->assertEquals($iat, $token->iat);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function jwtTokenProvider(): \Generator
+    {
+        yield [
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJpc3N0b2tlbiJ9.vcwW8PMPwPF2E-CkWflDrhAulR5dPWbbl-lOJheOwIY',
+            'secret',
+            'isstoken',
+            '1234567890',
+            'John Doe',
+            1516239022,
+        ];
+        yield [
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5ODc2NTQzMjEwIiwibmFtZSI6IkphbmUgRG9lIiwiaWF0IjoxNTE2MjM5MDIzLCJpc3MiOiJhbm90aGVySXNzVG9rZW4ifQ.wzTiSSNtS6rXoAYXL4tdmVzEbUvRd7BSuMq3kbboSA4',
+            'anotherSecret',
+            'anotherIssToken',
+            '9876543210',
+            'Jane Doe',
+            1516239023,
+        ];
+    }
+
+    /**
+     * test loadUserByUsername method
+     */
+    public function testLoadsUserByUserName(): void
+    {
+        $tenant = $this->createMock(TenantInterface::class);
+
+        $this->entityRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with([
+                'clientKey' => 'key',
+            ])
+            ->willReturn($tenant);
+
+        $result = $this->userProvider->loadUserByUsername('key');
+        $this->assertSame($result, $tenant);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
+     */
+    public function testItFailsToLoadAUserByUserName(): void
+    {
+        $this->entityRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with([
+                'clientKey' => 'key',
+            ])
+            ->willReturn(null);
+
+        $this->userProvider->loadUserByUsername('key');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\UnsupportedUserException
+     */
+    public function testRefreshUserIsNotSupported(): void
+    {
+        $this->userProvider->refreshUser($this->createMock(UserInterface::class));
+    }
+
+    /**
+     * @param mixed $class
+     * @param bool  $isSupported
+     *
+     * @dataProvider classProvider
+     */
+    public function testItSupportsAclass($class, bool $isSupported): void
+    {
+        $result = $this->userProvider->supportsClass($class);
+
+        $this->assertEquals($isSupported, $result);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function classProvider(): \Generator
+    {
+        yield [new Tenant(), true];
+        yield [new StubbedTenant(), true];
+        yield [new \stdClass(), false];
+    }
+}

--- a/Tests/Security/StubbedTenant.php
+++ b/Tests/Security/StubbedTenant.php
@@ -1,0 +1,172 @@
+<?php declare(strict_types = 1);
+
+namespace AtlassianConnectBundle\Tests\Security;
+
+use AtlassianConnectBundle\Entity\TenantInterface;
+use Symfony\Component\Security\Core\Role\Role;
+
+/**
+ * Class StubbedTenant
+ */
+class StubbedTenant implements TenantInterface
+{
+    /**
+     * @return string[]|Role[]
+     */
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSharedSecret(): ?string
+    {
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOauthClientId(): ?string
+    {
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBaseUrl(): ?string
+    {
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAddonKey(): ?string
+    {
+    }
+
+    /**
+     * @param string $name
+     * @return TenantInterface
+     */
+    public function setUsername(string $name): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $addonKey
+     * @return TenantInterface
+     */
+    public function setAddonKey(string $addonKey): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $clientKey
+     * @return TenantInterface
+     */
+    public function setClientKey(string $clientKey): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $publicKey
+     * @return TenantInterface
+     */
+    public function setPublicKey(string $publicKey): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $sharedSecret
+     * @return TenantInterface
+     */
+    public function setSharedSecret(string $sharedSecret): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $serverVersion
+     * @return TenantInterface
+     */
+    public function setServerVersion(string $serverVersion): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $pluginsVersion
+     * @return TenantInterface
+     */
+    public function setPluginsVersion(string $pluginsVersion): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $baseUrl
+     * @return TenantInterface
+     */
+    public function setBaseUrl(string $baseUrl): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $productType
+     * @return TenantInterface
+     */
+    public function setProductType(string $productType): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $description
+     * @return TenantInterface
+     */
+    public function setDescription(string $description): TenantInterface
+    {
+    }
+
+    /**
+     * @param string $eventType
+     * @return TenantInterface
+     */
+    public function setEventType(string $eventType): TenantInterface
+    {
+    }
+
+    /**
+     * @param string|null $oauthClientId
+     * @return TenantInterface
+     */
+    public function setOauthClientId(?string $oauthClientId): TenantInterface
+    {
+    }
+
+    /**
+     * @return string|void
+     */
+    public function getPassword(): ?string
+    {
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSalt(): ?string
+    {
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUsername(): ?string
+    {
+    }
+
+    /**
+     * @return void
+     */
+    public function eraseCredentials(): void
+    {
+    }
+}

--- a/src/Entity/Tenant.php
+++ b/src/Entity/Tenant.php
@@ -3,7 +3,6 @@
 namespace AtlassianConnectBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Tenant
@@ -12,7 +11,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity()
  */
-class Tenant implements UserInterface, TenantInterface
+class Tenant implements TenantInterface
 {
     use TenantTrait;
 }

--- a/src/Entity/TenantInterface.php
+++ b/src/Entity/TenantInterface.php
@@ -2,10 +2,12 @@
 
 namespace AtlassianConnectBundle\Entity;
 
+use Symfony\Component\Security\Core\User\UserInterface;
+
 /**
  * Interface TenantInterface
  */
-interface TenantInterface
+interface TenantInterface extends UserInterface
 {
     /**
      * @return string[]

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -53,14 +53,13 @@ services:
     jwt_user_provider:
         class: '%atlassian_connect_jwt_user_provider_class%'
         arguments:
-            $registry: '@Doctrine\Common\Persistence\ManagerRegistry'
+            $entityManager: '@Doctrine\ORM\EntityManagerInterface'
             $tenantClass: '%atlassian_connect_tenant_entity_class%'
 
     jwt_authenticator:
         class: "%atlassian_connect_jwt_authenticator_class%"
         arguments:
-            $userProvider: '@jwt_user_provider'
             $kernel: '@Symfony\Component\HttpKernel\KernelInterface'
-            $registry: '@Doctrine\Common\Persistence\ManagerRegistry'
+            $entityManager: '@Doctrine\ORM\EntityManagerInterface'
             $tenantEntityClass: '%atlassian_connect_tenant_entity_class%'
             $devTenant: '%atlassian_connect_dev_tenant%'

--- a/src/Security/JWTAuthenticator.php
+++ b/src/Security/JWTAuthenticator.php
@@ -4,9 +4,10 @@ namespace AtlassianConnectBundle\Security;
 
 use AtlassianConnectBundle\Entity\TenantInterface;
 use AtlassianConnectBundle\Service\QSHGenerator;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Firebase\JWT\JWT;
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -21,11 +22,6 @@ use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
  */
 class JWTAuthenticator extends AbstractGuardAuthenticator
 {
-    /**
-     * @var JWTUserProvider
-     */
-    protected $userProvider;
-
     /**
      * @var KernelInterface
      */
@@ -49,17 +45,15 @@ class JWTAuthenticator extends AbstractGuardAuthenticator
     /**
      * JWTAuthenticator constructor.
      *
-     * @param JWTUserProvider $userProvider
-     * @param KernelInterface $kernel
-     * @param ManagerRegistry $registry
-     * @param string          $tenantEntityClass
-     * @param int             $devTenant
+     * @param KernelInterface        $kernel
+     * @param EntityManagerInterface $entityManager
+     * @param string                 $tenantEntityClass
+     * @param int                    $devTenant
      */
-    public function __construct(JWTUserProvider $userProvider, KernelInterface $kernel, ManagerRegistry $registry, string $tenantEntityClass, int $devTenant)
+    public function __construct(KernelInterface $kernel, EntityManagerInterface $entityManager, string $tenantEntityClass, int $devTenant)
     {
-        $this->userProvider = $userProvider;
         $this->kernel = $kernel;
-        $this->em = $registry->getManager();
+        $this->em = $entityManager;
         $this->tenantEntityClass = $tenantEntityClass;
         $this->devTenant = $devTenant;
     }
@@ -132,7 +126,14 @@ class JWTAuthenticator extends AbstractGuardAuthenticator
      */
     public function getUser($credentials, UserProviderInterface $userProvider): ?UserInterface
     {
-        $token = $this->userProvider->getDecodedToken($credentials['jwt']);
+        if (!$userProvider instanceof JWTUserProviderInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                'UserProvider must implement %s',
+                JWTUserProviderInterface::class
+            ));
+        }
+
+        $token = $userProvider->getDecodedToken($credentials['jwt']);
         $clientKey = $token->iss;
 
         if (!$clientKey) {
@@ -142,7 +143,7 @@ class JWTAuthenticator extends AbstractGuardAuthenticator
         }
 
         /** @var TenantInterface|UserInterface $user */
-        $user = $this->userProvider->loadUserByUsername($clientKey);
+        $user = $userProvider->loadUserByUsername($clientKey);
         if (\property_exists($token, 'sub')) {
             // for some reasons, when webhooks are called - field sub is undefined
             $user->setUsername($token->sub);

--- a/src/Security/JWTUserProvider.php
+++ b/src/Security/JWTUserProvider.php
@@ -3,19 +3,18 @@
 namespace AtlassianConnectBundle\Security;
 
 use AtlassianConnectBundle\Entity\TenantInterface;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Firebase\JWT\JWT;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
  * Class JWTUserProvider
  */
-class JWTUserProvider implements UserProviderInterface
+class JWTUserProvider implements JWTUserProviderInterface
 {
     /**
      * @var EntityManager
@@ -30,19 +29,19 @@ class JWTUserProvider implements UserProviderInterface
     /**
      * JWTUserProvider constructor.
      *
-     * @param ManagerRegistry $registry
-     * @param string          $tenantClass
+     * @param EntityManagerInterface $entityManager
+     * @param string                 $tenantClass
      */
-    public function __construct(ManagerRegistry $registry, string $tenantClass)
+    public function __construct(EntityManagerInterface $entityManager, string $tenantClass)
     {
-        $this->em = $registry->getManager();
+        $this->em = $entityManager;
         $this->tenantClass = $tenantClass;
     }
 
     /**
      * @param string $jwt
      *
-     * @return mixed
+     * @return object|mixed
      */
     public function getDecodedToken(string $jwt)
     {
@@ -72,7 +71,7 @@ class JWTUserProvider implements UserProviderInterface
             throw new UsernameNotFoundException('Can\'t find tenant with such username');
         }
 
-        return $this->findTenant($clientKey);
+        return $tenant;
     }
 
     /**
@@ -96,14 +95,14 @@ class JWTUserProvider implements UserProviderInterface
     /**
      * @param string $clientKey
      *
-     * @return TenantInterface|null
+     * @return TenantInterface|object|null
      */
-    protected function findTenant(string $clientKey): ?TenantInterface
+    private function findTenant(string $clientKey): ?TenantInterface
     {
         /** @noinspection PhpUndefinedMethodInspection */
 
         return $this->em
             ->getRepository($this->tenantClass)
-            ->findOneByClientKey($clientKey);
+            ->findOneBy(['clientKey' => $clientKey]);
     }
 }

--- a/src/Security/JWTUserProviderInterface.php
+++ b/src/Security/JWTUserProviderInterface.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace AtlassianConnectBundle\Security;
+
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * @class JWTUserProviderInterface
+ */
+interface JWTUserProviderInterface extends UserProviderInterface
+{
+    /**
+     * @param string $jwt
+     *
+     * @return object|mixed
+     */
+    public function getDecodedToken(string $jwt);
+}


### PR DESCRIPTION
- Tenantinterface extends UserInterface (bc break)
- EntityManager is injected directly into provider and authenticator
- The injected userprovider is used in the authenticator (no more hard dependency)
- Tests were added