### PR TITLE
Fix: symfony 4.4

### DIFF
--- a/Tests/Listener/LicenseListenerTest.php
+++ b/Tests/Listener/LicenseListenerTest.php
@@ -15,7 +15,6 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Class LicenseListenerTest
@@ -42,6 +41,9 @@ final class LicenseListenerTest extends TestCase
      */
     private $listener;
 
+    /**
+     * setUp
+     */
     protected function setUp(): void
     {
         $this->router = $this->createMock(RouterInterface::class);
@@ -54,6 +56,9 @@ final class LicenseListenerTest extends TestCase
         );
     }
 
+    /**
+     * Test
+     */
     public function testItSkipsOnASubRequest(): void
     {
         $attributeParameterBag = $this->createMock(ParameterBagInterface::class);
@@ -73,7 +78,10 @@ final class LicenseListenerTest extends TestCase
         $this->listener->onKernelRequest($event);
     }
 
-    public function testItSkipsWhenTheRouteIsNullAndRouteRequiresNoLicense()
+    /**
+     * Test
+     */
+    public function testItSkipsWhenTheRouteIsNullAndRouteRequiresNoLicense(): void
     {
         $request = new Request(
             ['lic' => 'test'],
@@ -97,6 +105,9 @@ final class LicenseListenerTest extends TestCase
         $this->listener->onKernelRequest($event);
     }
 
+    /**
+     * Test
+     */
     public function testLicenseIsNotActiveOrDevelopment(): void
     {
         $request1 = new Request(
@@ -142,6 +153,9 @@ final class LicenseListenerTest extends TestCase
         $this->listener->onKernelRequest($event2);
     }
 
+    /**
+     * Test
+     */
     public function testUserIsNoTenant(): void
     {
         $request = new Request(
@@ -192,6 +206,9 @@ final class LicenseListenerTest extends TestCase
         $this->assertEquals('http://website.com', $response->getTargetUrl());
     }
 
+    /**
+     * Test
+     */
     public function testTenantIsWhiteListed(): void
     {
         $request = new Request(
@@ -235,6 +252,9 @@ final class LicenseListenerTest extends TestCase
         $this->listener->onKernelRequest($event);
     }
 
+    /**
+     * Test
+     */
     public function testIsValidByWhiteList(): void
     {
         $request = new Request(
@@ -291,6 +311,9 @@ final class LicenseListenerTest extends TestCase
         $this->assertNull($event->getResponse());
     }
 
+    /**
+     * Test
+     */
     public function testWhiteListIsExpired(): void
     {
         $request = new Request(
@@ -356,6 +379,9 @@ final class LicenseListenerTest extends TestCase
         $this->assertEquals('http://website.com', $response->getTargetUrl());
     }
 
+    /**
+     * Test
+     */
     public function testThrowsException(): void
     {
         $request = new Request(
@@ -397,28 +423,5 @@ final class LicenseListenerTest extends TestCase
         $response = $event->getResponse();
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('http://website.com', $response->getTargetUrl());
-    }
-}
-
-class TestUser implements UserInterface
-{
-    public function getRoles()
-    {
-    }
-
-    public function getPassword()
-    {
-    }
-
-    public function getSalt()
-    {
-    }
-
-    public function getUsername()
-    {
-    }
-
-    public function eraseCredentials()
-    {
     }
 }

--- a/Tests/Listener/LicenseListenerTest.php
+++ b/Tests/Listener/LicenseListenerTest.php
@@ -1,0 +1,424 @@
+<?php declare(strict_types = 1);
+
+namespace AtlassianConnectBundle\Tests\Listener;
+
+use AtlassianConnectBundle\Entity\Tenant;
+use AtlassianConnectBundle\Listener\LicenseListener;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Class LicenseListenerTest
+ */
+final class LicenseListenerTest extends TestCase
+{
+    /**
+     * @var MockObject|KernelInterface
+     */
+    private $kernel;
+
+    /**
+     * @var MockObject|RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var MockObject|TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var LicenseListener
+     */
+    private $listener;
+
+    protected function setUp(): void
+    {
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->kernel = $this->createMock(KernelInterface::class);
+        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+
+        $this->listener = new LicenseListener(
+            $this->router,
+            $this->tokenStorage
+        );
+    }
+
+    public function testItSkipsOnASubRequest(): void
+    {
+        $attributeParameterBag = $this->createMock(ParameterBagInterface::class);
+        $attributeParameterBag
+            ->expects($this->never())
+            ->method('get');
+
+        $request = new Request();
+        $request->attributes = $attributeParameterBag;
+
+        $event = new GetResponseEvent(
+            $this->kernel,
+            $request,
+            KernelInterface::SUB_REQUEST
+        );
+
+        $this->listener->onKernelRequest($event);
+    }
+
+    public function testItSkipsWhenTheRouteIsNullAndRouteRequiresNoLicense()
+    {
+        $request = new Request(
+            ['lic' => 'test'],
+            [],
+            [
+                '_route' => 'route',
+                'requires_license' => false,
+            ]
+        );
+
+        $this->kernel
+            ->expects($this->never())
+            ->method('getEnvironment');
+
+        $event = new GetResponseEvent(
+            $this->kernel,
+            $request,
+            KernelInterface::MASTER_REQUEST
+        );
+
+        $this->listener->onKernelRequest($event);
+    }
+
+    public function testLicenseIsNotActiveOrDevelopment(): void
+    {
+        $request1 = new Request(
+            ['lic' => 'active'],
+            [],
+            [
+                '_route' => 'route',
+                'requires_license' => true,
+            ]
+        );
+
+        $request2 = new Request(
+            ['lic' => 'notactive'],
+            [],
+            [
+                '_route' => 'route',
+                'requires_license' => true,
+            ]
+        );
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getEnvironment')
+            ->willReturn('dev');
+
+        $this->tokenStorage
+            ->expects($this->never())
+            ->method('getToken');
+
+        $event1 = new GetResponseEvent(
+            $this->kernel,
+            $request1,
+            KernelInterface::MASTER_REQUEST
+        );
+
+        $event2 = new GetResponseEvent(
+            $this->kernel,
+            $request2,
+            KernelInterface::MASTER_REQUEST
+        );
+
+        $this->listener->onKernelRequest($event1);
+        $this->listener->onKernelRequest($event2);
+    }
+
+    public function testUserIsNoTenant(): void
+    {
+        $request = new Request(
+            ['lic' => 'not_active'],
+            [],
+            [
+                '_route' => 'route',
+                'requires_license' => true,
+            ]
+        );
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getEnvironment')
+            ->willReturn('prod');
+
+        $this->kernel
+            ->expects($this->never())
+            ->method('getContainer');
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn(new TestUser());
+
+        $this->tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->willReturn($token);
+
+        $this->router
+            ->expects($this->once())
+            ->method('generate')
+            ->with('atlassian_connect_unlicensed')
+            ->willReturn('http://website.com');
+
+        $event = new GetResponseEvent(
+            $this->kernel,
+            $request,
+            KernelInterface::MASTER_REQUEST
+        );
+
+        $this->listener->onKernelRequest($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertEquals('http://website.com', $response->getTargetUrl());
+    }
+
+    public function testTenantIsWhiteListed(): void
+    {
+        $request = new Request(
+            ['lic' => 'not_active'],
+            [],
+            [
+                '_route' => 'route',
+                'requires_license' => true,
+            ]
+        );
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getEnvironment')
+            ->willReturn('prod');
+
+        $user = new Tenant();
+        $user->setIsWhiteListed(true);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+
+        $this->tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->willReturn($token);
+
+        $this->kernel
+            ->expects($this->never())
+            ->method('getContainer');
+
+        $event = new GetResponseEvent(
+            $this->kernel,
+            $request,
+            KernelInterface::MASTER_REQUEST
+        );
+
+        $this->listener->onKernelRequest($event);
+    }
+
+    public function testIsValidByWhiteList(): void
+    {
+        $request = new Request(
+            ['lic' => 'not_active'],
+            [],
+            [
+                '_route' => 'route',
+                'requires_license' => true,
+            ]
+        );
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getEnvironment')
+            ->willReturn('prod');
+
+        $user = new Tenant();
+        $user->setClientKey('key');
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+
+        $this->tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->willReturn($token);
+
+        $date = new \DateTime();
+        $date->modify('+1 day');
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('getParameter')
+            ->willReturn([
+                ['valid_till' => $date->format('Y-m-d'), 'client_key' => 'key'],
+            ]);
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getContainer')
+            ->willReturn($container);
+
+        $event = new GetResponseEvent(
+            $this->kernel,
+            $request,
+            KernelInterface::MASTER_REQUEST
+        );
+
+        $this->listener->onKernelRequest($event);
+        $this->assertNull($event->getResponse());
+    }
+
+    public function testWhiteListIsExpired(): void
+    {
+        $request = new Request(
+            ['lic' => 'not_active'],
+            [],
+            [
+                '_route' => 'route',
+                'requires_license' => true,
+            ]
+        );
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getEnvironment')
+            ->willReturn('prod');
+
+        $user = new Tenant();
+        $user->setClientKey('key');
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+
+        $this->tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->willReturn($token);
+
+        $date = new \DateTime();
+        $date->modify('-1 day');
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('getParameter')
+            ->willReturn([
+                ['valid_till' => $date->format('Y-m-d'), 'client_key' => 'key'],
+            ]);
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getContainer')
+            ->willReturn($container);
+
+        $this->router
+            ->expects($this->once())
+            ->method('generate')
+            ->with('atlassian_connect_unlicensed')
+            ->willReturn('http://website.com');
+
+        $event = new GetResponseEvent(
+            $this->kernel,
+            $request,
+            KernelInterface::MASTER_REQUEST
+        );
+
+        $this->listener->onKernelRequest($event);
+        $this->assertNotNull($event->getResponse());
+        $response = $event->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertEquals('http://website.com', $response->getTargetUrl());
+    }
+
+    public function testThrowsException(): void
+    {
+        $request = new Request(
+            ['lic' => 'not_active'],
+            [],
+            [
+                '_route' => 'route',
+                'requires_license' => true,
+            ]
+        );
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getEnvironment')
+            ->willReturn('prod');
+
+        $user = new Tenant();
+        $user->setClientKey('key');
+
+        $this->tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->willThrowException(new \Exception());
+
+        $this->router
+            ->expects($this->once())
+            ->method('generate')
+            ->with('atlassian_connect_unlicensed')
+            ->willReturn('http://website.com');
+
+        $event = new GetResponseEvent(
+            $this->kernel,
+            $request,
+            KernelInterface::MASTER_REQUEST
+        );
+
+        $this->listener->onKernelRequest($event);
+        $this->assertNotNull($event->getResponse());
+        $response = $event->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertEquals('http://website.com', $response->getTargetUrl());
+    }
+}
+
+class TestUser implements UserInterface
+{
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}

--- a/Tests/Listener/Testuser.php
+++ b/Tests/Listener/Testuser.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace AtlassianConnectBundle\Tests\Listener;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Class TestUser
+ */
+final class TestUser implements UserInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function getRoles()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPassword()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSalt()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUsername()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function eraseCredentials()
+    {
+    }
+}

--- a/src/Listener/LicenseListener.php
+++ b/src/Listener/LicenseListener.php
@@ -5,9 +5,8 @@ namespace AtlassianConnectBundle\Listener;
 use AtlassianConnectBundle\Entity\TenantInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class LicenseListener
@@ -20,23 +19,17 @@ class LicenseListener
     protected $router;
 
     /**
-     * @var KernelInterface
-     */
-    protected $kernel;
-    /**
-     * @var TokenStorage
+     * @var TokenStorageInterface
      */
     protected $tokenStorage;
 
     /**
-     * @param RouterInterface $router
-     * @param KernelInterface $kernel
-     * @param TokenStorage    $tokenStorage
+     * @param RouterInterface       $router
+     * @param TokenStorageInterface $tokenStorage
      */
-    public function __construct(RouterInterface $router, KernelInterface $kernel, TokenStorage $tokenStorage)
+    public function __construct(RouterInterface $router, TokenStorageInterface $tokenStorage)
     {
         $this->router = $router;
-        $this->kernel = $kernel;
         $this->tokenStorage = $tokenStorage;
     }
 
@@ -53,12 +46,13 @@ class LicenseListener
 
         $request = $event->getRequest();
         $route = $request->attributes->get('_route');
+        $kernel = $event->getKernel();
 
         if ($route !== null && !$request->attributes->get('requires_license')) {
             return;
         }
 
-        if ($request->get('lic') === 'active' || $this->kernel->getEnvironment() !== 'prod') {
+        if ($request->get('lic') === 'active' || $kernel->getEnvironment() !== 'prod') {
             return;
         }
 
@@ -73,7 +67,7 @@ class LicenseListener
                 }
 
                 $today = \date('Y-m-d');
-                $whitelist = $this->kernel->getContainer()->getParameter('license_whitelist');
+                $whitelist = $kernel->getContainer()->getParameter('license_whitelist');
 
                 /** @noinspection ForeachSourceInspection */
                 foreach ($whitelist as $allowed) {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -45,7 +45,6 @@ services:
         class: '%atlassian_connect_license_listener_class%'
         arguments:
             $router: '@Symfony\Component\Routing\RouterInterface'
-            $kernel: '@Symfony\Component\HttpKernel\KernelInterface'
             $tokenStorage: '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }


### PR DESCRIPTION
Symfony 4.4 passes UsageTrackingTokenStorage instead of the normal TokenStorage so we implement use TokenStorageInterface in the LicenseListener constructor now.

I also removed the KernelInterface variable from the constructor as it exists in the event.

Tests for LicenseListener are added.