### PR TITLE
Use ManagerRegistry from Persistence library instead of common library

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,7 @@
+build:
+    environment:
+        php:
+            version: 7.4
 checks:
     php: true
 

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
   "require-dev": {
     "escapestudios/symfony2-coding-standard": "^3.0",
     "friendsofphp/php-cs-fixer": "^2.3",
-    "slevomat/coding-standard": "^5.0",
-    "phpunit/phpunit": "^8.3"
+    "phpunit/phpunit": "^8.3",
+    "slevomat/coding-standard": "^6.4"
   },
   "authors": [
     {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -35,6 +35,22 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming.SuperfluousSuffix"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator.UselessTernaryOperator"/>
         <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall.MissingTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
+        <exclude name="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
+        <exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+        <exclude name="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
+        <exclude name="SlevomatCodingStandard.Functions.DisallowEmptyFunction"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireArrowFunction"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireMultiLineCall"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireSingleLineCall"/>
+        <exclude name="SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature"/>
+        <exclude name="SlevomatCodingStandard.Classes.ClassStructure"/>
+        <exclude name="SlevomatCodingStandard.Files.LineLength"/>
+        <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
+        <exclude name="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">

--- a/src/Command/RequestAPICommand.php
+++ b/src/Command/RequestAPICommand.php
@@ -4,7 +4,7 @@ namespace AtlassianConnectBundle\Command;
 
 use AtlassianConnectBundle\Entity\TenantInterface;
 use AtlassianConnectBundle\Service\AtlassianRestClient;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -33,7 +33,7 @@ services:
     AtlassianConnectBundle\Command\RequestAPICommand:
         public: false
         arguments:
-            $registry: '@Doctrine\Common\Persistence\ManagerRegistry'
+            $registry: '@Doctrine\Persistence\ManagerRegistry'
             $tenantClass: '%atlassian_connect_tenant_entity_class%'
 
     AtlassianConnectBundle\Service\AtlassianRestClient:


### PR DESCRIPTION
The ManagerRegistry class was removed from the doctrine commons package and lives in the doctrine/persistence package.

When using doctrine/commons 3.*, I got the following error:

```
Argument 1 passed to AtlassianConnectBundle\Command\RequestAPICommand::__construct() must be an instance of Doctrine\Common\Persistence\ManagerRegistry, instance of Doctrine\Bundle\DoctrineBundle\Registry given, called in /Users/matthieu/Sites/scw/content-management-system/var/cache/dev/ContainerAGM919k/getRe  
  questAPICommandService.php on line 23 
```