### PR TITLE
Update guzzle library to support guzzle 7

### DIFF
--- a/Tests/Service/GuzzleJWTMiddlewareTest.php
+++ b/Tests/Service/GuzzleJWTMiddlewareTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace AtlassianConnectBundle\Tests\Service;
+
+use AtlassianConnectBundle\Service\GuzzleJWTMiddleware;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class GuzzleJWTMiddlewareTest
+ *
+ * @covers \AtlassianConnectBundle\Service\GuzzleJWTMiddleware
+ */
+final class GuzzleJWTMiddlewareTest extends TestCase
+{
+    /**
+     * Test if authorization header is set when using auth tokens
+     */
+    public function testAuthTokenMiddleware(): void
+    {
+        $middleware = GuzzleJWTMiddleware::authTokenMiddleware('atlassian-connect', 'secret');
+
+        $invokable = $middleware(function (Request $request, array $options) {
+            $this->assertTrue($request->hasHeader('Authorization'));
+            $this->assertTrue($request->hasHeader('existing-header'));
+            $this->assertSame('GET', $request->getMethod());
+            $this->assertEquals(new Uri('https://atlassian.io/api/test'), $request->getUri());
+        });
+
+        $request = new Request('GET', 'https://atlassian.io/api/test', [
+            'existing-header' => 'existing-value',
+        ]);
+
+        $invokable($request, []);
+    }
+
+    /**
+     * Test if authorization and accept headers are set with user auth middleware
+     */
+    public function testAuthUserTokenMiddleware(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], \json_encode(['access_token' => 'token'])),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $middleware = GuzzleJWTMiddleware::authUserTokenMiddleware(
+            $client,
+            'oathClientId',
+            'secret',
+            'https://atlassian.io',
+            'username'
+        );
+
+        $invokable = $middleware(function (Request $request, array $options) {
+            $this->assertSame('application/json', $request->getHeader('Accept')[0]);
+            $this->assertSame('Bearer token', $request->getHeader('Authorization')[0]);
+            $this->assertEquals(new Uri('https://atlassian.io/api/test'), $request->getUri());
+        });
+
+        $request = new Request('GET', 'https://atlassian.io/api/test', [
+            'existing-header' => 'existing-value',
+        ]);
+
+        $invokable($request, []);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "symfony/routing": "^3.4|^4.3|^5.0",
     "symfony/console": "^3.4|^4.3|^5.0",
     "doctrine/orm": "^2.5",
-    "guzzlehttp/guzzle": "^6.0",
+    "guzzlehttp/guzzle": "^6.0|^7.0",
     "twig/twig": "^2.10|^3.0",
     "firebase/php-jwt": "^5.0"
   },

--- a/src/Service/AtlassianRestClient.php
+++ b/src/Service/AtlassianRestClient.php
@@ -166,6 +166,7 @@ class AtlassianRestClient
             ));
         } else {
             $stack->push(GuzzleJWTMiddleware::authUserTokenMiddleware(
+                new Client(),
                 $this->tenant->getOauthClientId(),
                 $this->tenant->getSharedSecret(),
                 $this->tenant->getBaseUrl(),

--- a/src/Service/GuzzleJWTMiddleware.php
+++ b/src/Service/GuzzleJWTMiddleware.php
@@ -2,9 +2,9 @@
 
 namespace AtlassianConnectBundle\Service;
 
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -24,53 +24,60 @@ class GuzzleJWTMiddleware
     {
         return Middleware::mapRequest(
             static function (RequestInterface $request) use ($issuer, $secret) {
-                return new Request(
-                    $request->getMethod(),
-                    $request->getUri(),
-                    \array_merge($request->getHeaders(), ['Authorization' => 'JWT '.JWTGenerator::generate($request, $issuer, $secret)]),
-                    $request->getBody()
+                return $request->withHeader(
+                    'Authorization',
+                    'JWT '.JWTGenerator::generate($request, $issuer, $secret)
                 );
             }
         );
     }
 
     /**
-     * @param string $oauthClientId
-     * @param string $secret
-     * @param string $baseUrl
-     * @param string $username
+     * @param ClientInterface $client
+     * @param string          $oauthClientId
+     * @param string          $secret
+     * @param string          $baseUrl
+     * @param string          $username
      *
      * @return callable
      */
-    public static function authUserTokenMiddleware(string $oauthClientId, string $secret, string $baseUrl, string $username): callable
-    {
+    public static function authUserTokenMiddleware(
+        ClientInterface $client,
+        string $oauthClientId,
+        string $secret,
+        string $baseUrl,
+        string $username
+    ): callable {
         return Middleware::mapRequest(
-            static function (RequestInterface $request) use ($oauthClientId, $secret, $baseUrl, $username) {
-                return new Request(
-                    $request->getMethod(),
-                    $request->getUri(),
-                    \array_merge($request->getHeaders(), [
-                        'Authorization' => 'Bearer '.self::getAuthToken($oauthClientId, $secret, $baseUrl, $username),
-                        'Accept' => 'application/json',
-                    ]),
-                    $request->getBody()
-                );
+            static function (RequestInterface $request) use ($client, $oauthClientId, $secret, $baseUrl, $username) {
+                return $request
+                    ->withHeader('Accept', 'application/json')
+                    ->withHeader(
+                        'Authorization',
+                        'Bearer '.self::getAuthToken($client, $oauthClientId, $secret, $baseUrl, $username)
+                    );
             }
         );
     }
 
     /**
-     * @param string $oauthClientId
-     * @param string $secret
-     * @param string $baseUrl
-     * @param string $username
+     * @param ClientInterface $client
+     * @param string          $oauthClientId
+     * @param string          $secret
+     * @param string          $baseUrl
+     * @param string          $username
      *
      * @return string
      */
-    private static function getAuthToken(string $oauthClientId, string $secret, string $baseUrl, string $username): string
-    {
-        $result = (new Client())->post('https://auth.atlassian.io/oauth2/token', [
-            'form_params' => [
+    private static function getAuthToken(
+        ClientInterface $client,
+        string $oauthClientId,
+        string $secret,
+        string $baseUrl,
+        string $username
+    ): string {
+        $result = $client->request('POST', 'https://auth.atlassian.io/oath2/token', [
+            RequestOptions::FORM_PARAMS => [
                 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
                 'assertion' => JWTGenerator::generateAssertion($secret, $oauthClientId, $baseUrl, $username),
             ],


### PR DESCRIPTION
Added unit tests for the guzzle middleware as well.
The client is now an argument for the static method for easy
testing.