### PR TITLE
Do not expose the exception message

### DIFF
--- a/Tests/Functional/AuthenticationTest.php
+++ b/Tests/Functional/AuthenticationTest.php
@@ -58,6 +58,18 @@ final class AuthenticationTest extends AbstractWebTestCase
     }
 
     /**
+     * test authentication with invalid jwt token
+     */
+    public function testProtectedRouteWithInvalidJWTToken(): void
+    {
+        $client = self::createClient(['environment' => 'prod']);
+
+        $client->request('GET', '/protected/route?jwt=invalid');
+        $this->assertResponseStatusCodeSame(403);
+        $this->assertEquals('Authentication Failed: Failed to parse token', $client->getResponse()->getContent());
+    }
+
+    /**
      * @return string
      */
     public function getTenantJWTCode(): string

--- a/Tests/Security/JWTUserProviderTest.php
+++ b/Tests/Security/JWTUserProviderTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -104,6 +105,16 @@ final class JWTUserProviderTest extends TestCase
             'Jane Doe',
             1516239023,
         ];
+    }
+
+    /**
+     * test decoded token fails
+     */
+    public function testItFailsToDecodeToken(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Failed to parse token');
+        $this->userProvider->getDecodedToken('invalid_token');
     }
 
     /**

--- a/src/Security/JWTUserProvider.php
+++ b/src/Security/JWTUserProvider.php
@@ -56,7 +56,7 @@ class JWTUserProvider implements JWTUserProviderInterface
 
             return $decodedToken;
         } catch (\Throwable $e) {
-            throw new AuthenticationException($e->getMessage());
+            throw new AuthenticationException("Failed to parse token");
         }
     }
 


### PR DESCRIPTION
Sometimes the message can include class information or code.
This change gives a generic exception message.