### PR TITLE
Updated OAuth 2.0 endpoint

### DIFF
--- a/src/Service/GuzzleJWTMiddleware.php
+++ b/src/Service/GuzzleJWTMiddleware.php
@@ -76,7 +76,7 @@ class GuzzleJWTMiddleware
         string $baseUrl,
         string $username
     ): string {
-        $result = $client->request('POST', 'https://auth.atlassian.io/oath2/token', [
+        $result = $client->request('POST', 'https://oauth-2-authorization-server.services.atlassian.com/oauth2/token', [
             RequestOptions::FORM_PARAMS => [
                 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
                 'assertion' => JWTGenerator::generateAssertion($secret, $oauthClientId, $baseUrl, $username),

--- a/src/Service/JWTGenerator.php
+++ b/src/Service/JWTGenerator.php
@@ -47,7 +47,7 @@ class JWTGenerator
             'iat' => \time(),
             'exp' => \strtotime('+1 minutes'),
             'tnt' => $baseUrl,
-            'aud' => 'https://auth.atlassian.io',
+            'aud' => 'https://oauth-2-authorization-server.services.atlassian.com',
         ];
 
         return JWT::encode($data, $secret);


### PR DESCRIPTION
The old endpoint was removed. Updated to new endpoint.

Link: https://community.developer.atlassian.com/t/deprecation-notice-oauth-2-0-endpoint-for-auth-atlassian-io-url-is-changing/39600